### PR TITLE
feat: add support for new market

### DIFF
--- a/lib/ukio/apartments/apartment.ex
+++ b/lib/ukio/apartments/apartment.ex
@@ -8,14 +8,19 @@ defmodule Ukio.Apartments.Apartment do
     field :name, :string
     field :square_meters, :integer
     field :zip_code, :string
+    field :market, :string, default: "earth"
 
     timestamps()
   end
 
+  @enforce_keys [:market]
+  @valid_markets ["mars", "earth", "jupiter", "saturn", "uranus", "neptune", "pluto"]
+
   @doc false
   def changeset(apartment, attrs) do
     apartment
-    |> cast(attrs, [:name, :address, :zip_code, :monthly_price, :square_meters])
-    |> validate_required([:name, :address, :zip_code, :monthly_price, :square_meters])
+    |> cast(attrs, [:name, :address, :zip_code, :monthly_price, :square_meters, :market])
+    |> validate_inclusion(:market, @valid_markets)
+    |> validate_required([:name, :address, :zip_code, :monthly_price, :square_meters, :market])
   end
 end

--- a/lib/ukio/bookings/handlers/booking_creator.ex
+++ b/lib/ukio/bookings/handlers/booking_creator.ex
@@ -1,6 +1,7 @@
 defmodule Ukio.Bookings.Handlers.BookingCreator do
   alias Ukio.Apartments
   alias Ukio.Apartments.Handlers.AvailabilityChecker
+  @utilities_fee_multiplier %{"mars" => 150}
 
   def create(
         %{"check_in" => check_in, "check_out" => check_out, "apartment_id" => apartment_id} =
@@ -20,14 +21,29 @@ defmodule Ukio.Bookings.Handlers.BookingCreator do
     end
   end
 
-  defp generate_booking_data(apartment, check_in, check_out) do
-    %{
-      apartment_id: apartment.id,
-      check_in: check_in,
-      check_out: check_out,
-      monthly_rent: apartment.monthly_price,
-      utilities: 20_000,
-      deposit: 100_000
-    }
+  def generate_booking_data(apartment, check_in, check_out) do
+    if apartment.market == "mars" do
+      %{
+        apartment_id: apartment.id,
+        check_in: check_in,
+        check_out: check_out,
+        monthly_rent: apartment.monthly_price,
+        utilities: calculate_utilities_amount(apartment.market, apartment.square_meters),
+        deposit: apartment.monthly_price
+      }
+    else
+      %{
+        apartment_id: apartment.id,
+        check_in: check_in,
+        check_out: check_out,
+        monthly_rent: apartment.monthly_price,
+        utilities: 20_000,
+        deposit: 100_000
+      }
+    end
+  end
+
+  defp calculate_utilities_amount(market, square_meters) do
+    @utilities_fee_multiplier[market] * square_meters
   end
 end

--- a/lib/ukio_web/controllers/apartment_controller.ex
+++ b/lib/ukio_web/controllers/apartment_controller.ex
@@ -2,11 +2,20 @@ defmodule UkioWeb.ApartmentController do
   use UkioWeb, :controller
 
   alias Ukio.Apartments
+  alias Ukio.Apartments.Apartment
 
   action_fallback UkioWeb.FallbackController
 
   def index(conn, _params) do
     apartments = Apartments.list_apartments()
     render(conn, :index, apartments: apartments)
+  end
+
+  def create(conn, %{"apartment" => apartment_params}) do
+    with {:ok, %Apartment{} = apartment} <- Apartments.create_apartment(apartment_params) do
+      conn
+      |> put_status(:created)
+      |> render(:show, apartment: apartment)
+    end
   end
 end

--- a/lib/ukio_web/controllers/apartment_json.ex
+++ b/lib/ukio_web/controllers/apartment_json.ex
@@ -22,7 +22,8 @@ defmodule UkioWeb.ApartmentJSON do
       address: apartment.address,
       zip_code: apartment.zip_code,
       monthly_price: apartment.monthly_price,
-      square_meters: apartment.square_meters
+      square_meters: apartment.square_meters,
+      market: apartment.market
     }
   end
 end

--- a/lib/ukio_web/router.ex
+++ b/lib/ukio_web/router.ex
@@ -23,7 +23,7 @@ defmodule UkioWeb.Router do
   scope "/api", UkioWeb do
     pipe_through :api
 
-    get "/apartments", ApartmentController, :index
+    resources "/apartments", ApartmentController, [:index, :create]
     resources "/bookings", BookingController, [:show, :create]
   end
 

--- a/priv/repo/migrations/20230413161542_add_market_to_apartments.exs
+++ b/priv/repo/migrations/20230413161542_add_market_to_apartments.exs
@@ -1,0 +1,19 @@
+defmodule Ukio.Repo.Migrations.AddMarketToApartments do
+  use Ecto.Migration
+
+  def up do
+    execute "CREATE TYPE apartment_market AS ENUM ('mars', 'earth', 'jupiter', 'saturn', 'uranus', 'neptune', 'pluto')"
+
+    alter table(:apartments) do
+      add :market, :apartment_market, default: "earth"
+    end
+  end
+
+  def down do
+    alter table(:apartments) do
+      remove :market
+    end
+
+    execute "DROP TYPE apartment_market"
+  end
+end

--- a/test/ukio/booking_creator_test.exs
+++ b/test/ukio/booking_creator_test.exs
@@ -1,0 +1,61 @@
+defmodule Ukio.BookingCreatorTest do
+  use Ukio.DataCase
+
+  alias Ukio.Apartments
+  alias Ukio.Apartments.Apartment
+  alias Ukio.Bookings.Handlers.BookingCreator
+  import Ukio.ApartmentsFixtures
+
+  describe "generate_booking_data/3" do
+    @mars_apartment_attrs %{
+      address: "some address",
+      monthly_price: 50000,
+      name: "some name",
+      square_meters: 100,
+      zip_code: "some zip_code",
+      market: "mars"
+    }
+    @earth_apartment_attrs %{
+      address: "some address",
+      monthly_price: 30000,
+      name: "some name",
+      square_meters: 150,
+      zip_code: "some zip_code",
+      market: "earth"
+    }
+  end
+
+  test "generates data for Mars market" do
+    apartment = apartment_fixture(@mars_apartment_attrs)
+    check_in = Date.utc_today()
+    check_out = Date.utc_today() |> Date.add(30)
+
+    expected_result = %{
+      apartment_id: apartment.id,
+      check_in: check_in,
+      check_out: check_out,
+      monthly_rent: 50000,
+      utilities: 15000,
+      deposit: 50000
+    }
+
+    assert BookingCreator.generate_booking_data(apartment, check_in, check_out) == expected_result
+  end
+
+  test "generates data for non-Mars market" do
+    apartment = apartment_fixture(@earth_apartment_attrs)
+    check_in = Date.utc_today()
+    check_out = Date.utc_today() |> Date.add(30)
+
+    expected_result = %{
+      apartment_id: apartment.id,
+      check_in: check_in,
+      check_out: check_out,
+      monthly_rent: 30000,
+      utilities: 20000,
+      deposit: 100_000
+    }
+
+    assert BookingCreator.generate_booking_data(apartment, check_in, check_out) == expected_result
+  end
+end


### PR DESCRIPTION
This PR focus on the second requirement:

 _As we're expanding, we've discovered that not all markets work in the same way. Our next market, "Mars", has different deposit and utilities conditions:
The deposit is a full monthly rent
Utilities are not a fixed amount and are linked to the apartments' square meters._

As we are only adding one market and this is a small test with limited time, I decided to just add a new field `:market` to the `Apartment` model. If we think about how Ukio is growing and its fast expansion, with more time, a better choice  might have been to create a new `Market` model and then create a 1:1 `Apartment` <> `Market` relationship.

I think to solve this particular case, this implementation is enough.